### PR TITLE
item is converted to string before matching

### DIFF
--- a/lib/text-filter.js
+++ b/lib/text-filter.js
@@ -35,7 +35,8 @@ module.exports = function createTextFilter(options) {
     var searchable =  fields ? getFields(fields, item) : [item];
     return searchable.some(function(item) {
       return regexps.every(function(regexp) {
-        return item.match(regexp);
+        var convertedItem = item.toString();
+        return convertedItem.match(regexp);
       });
     });
   };


### PR DESCRIPTION
Hi, 
FIrst thanks for the nice npm package. We are using it for all of our applications. but there is one thing that must be fixed. The validation if the item that is to be matched is string or not. cause 

item.match(regx) works if only item is string. if it is of different type there will be an error. Please accept this pull request. and I will be highly pleased if you add me one of the contributor of the npm. Here is my npm profile details: 

email: rafiuddaularefat@gmail.com
userName: onlyrefat
